### PR TITLE
Use cats-effect IO data type

### DIFF
--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -20,7 +20,7 @@ object ProjectPlugin extends AutoPlugin {
       val catsEffect: String   = "1.1.0"
       val mdoc: String         = "2.1.1"
       val moultingyaml: String = "0.4.1"
-      val orgPolicies: String  = "0.13.1"
+      val orgPolicies: String  = "0.13.2"
       val scala: String        = "2.12.10"
       val scalactic: String    = "3.1.1"
       val scalatest: String    = "3.1.1"

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -17,7 +17,7 @@ object ProjectPlugin extends AutoPlugin {
   object autoImport {
 
     lazy val V = new {
-      val catsEffect: String   = "1.1.0"
+      val catsEffect: String   = "2.1.2"
       val mdoc: String         = "2.1.1"
       val moultingyaml: String = "0.4.1"
       val orgPolicies: String  = "0.13.2"

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -17,6 +17,7 @@ object ProjectPlugin extends AutoPlugin {
   object autoImport {
 
     lazy val V = new {
+      val catsEffect: String   = "1.1.0"
       val mdoc: String         = "2.1.1"
       val moultingyaml: String = "0.4.1"
       val orgPolicies: String  = "0.13.1"
@@ -40,6 +41,7 @@ object ProjectPlugin extends AutoPlugin {
       addSbtPlugin(%("sbt-ghpages", isSbtPlugin = true)),
       addSbtPlugin(%("sbt-site", isSbtPlugin = true)),
       libraryDependencies ++= Seq(
+        "org.typelevel" %% "cats-effect" % V.catsEffect,
         %%("org-policies-core", V.orgPolicies),
         %%("moultingyaml", V.moultingyaml),
         %%("scalatags", V.scalatags),

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ import sbt.Resolver.sonatypeRepo
 resolvers ++= Seq(sonatypeRepo("snapshots"), sonatypeRepo("releases"))
 
 addSbtPlugin("com.47deg"        % "sbt-org-policies" % "0.13.2")
-addSbtPlugin("com.47deg"        % "sbt-microsites"   % "1.1.3")
+addSbtPlugin("com.47deg"        % "sbt-microsites"   % "1.1.4-SNAPSHOT")
 addSbtPlugin("com.eed3si9n"     % "sbt-buildinfo"    % "0.9.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-site"         % "1.4.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages"      % "0.6.3")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ import sbt.Resolver.sonatypeRepo
 resolvers ++= Seq(sonatypeRepo("snapshots"), sonatypeRepo("releases"))
 
 addSbtPlugin("com.47deg"        % "sbt-org-policies" % "0.13.2")
-addSbtPlugin("com.47deg"        % "sbt-microsites"   % "1.1.4-SNAPSHOT")
+addSbtPlugin("com.47deg"        % "sbt-microsites"   % "1.1.3")
 addSbtPlugin("com.eed3si9n"     % "sbt-buildinfo"    % "0.9.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-site"         % "1.4.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages"      % "0.6.3")

--- a/src/main/scala/microsites/MicrositeKeys.scala
+++ b/src/main/scala/microsites/MicrositeKeys.scala
@@ -31,6 +31,8 @@ import mdoc.MdocPlugin.autoImport._
 import sbtorgpolicies.io.FileReader
 import sbtorgpolicies.io.FileWriter._
 import sbtorgpolicies.io.syntax._
+//import sbtorgpolicies.io.{IO => FIO}
+import cats.effect.{IO}
 
 import scala.sys.process._
 import java.nio.file._
@@ -506,9 +508,9 @@ trait MicrositeAutoImportSettings extends MicrositeKeys {
                  | * repo: $githubOwner/$githubRepo
                  | * commitMessage: $commitMessage""".stripMargin)
 
-            val ghOps: GitHubOps = new GitHubOps(githubOwner, githubRepo, githubToken)
+            val ghOps: GitHubOps = new GitHubOps[IO](githubOwner, githubRepo, githubToken)
 
-            if (noJekyll) IO.touch(siteDir / ".nojekyll")
+//            if (noJekyll) FIO.touch(siteDir / ".nojekyll")
 
             ghOps.commitDir(branch, commitMessage, siteDir) match {
               case Right(_) => log.info("Success committing files")

--- a/src/main/scala/microsites/MicrositeKeys.scala
+++ b/src/main/scala/microsites/MicrositeKeys.scala
@@ -24,6 +24,7 @@ import io.circe.generic.semiauto._
 import io.circe.syntax._
 import sbt.Keys._
 import sbt._
+import sbt.io.{IO => FIO}
 import sbt.complete.DefaultParsers.OptNotSpace
 import sbtorgpolicies.github.GitHubOps
 import tut.TutPlugin.autoImport._
@@ -31,8 +32,8 @@ import mdoc.MdocPlugin.autoImport._
 import sbtorgpolicies.io.FileReader
 import sbtorgpolicies.io.FileWriter._
 import sbtorgpolicies.io.syntax._
-//import sbtorgpolicies.io.{IO => FIO}
-import cats.effect.{IO}
+import cats.effect.{ContextShift, IO, Timer}
+import scala.concurrent.ExecutionContext
 
 import scala.sys.process._
 import java.nio.file._
@@ -496,6 +497,10 @@ trait MicrositeAutoImportSettings extends MicrositeKeys {
       val githubRepo: String            = micrositeGithubRepo.value
       val githubToken: Option[String]   = micrositeGithubToken.value
 
+      implicit val cs: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
+      implicit val ec: ExecutionContext = ExecutionContext.global
+      implicit val t: Timer[IO]         = IO.timer(ExecutionContext.global)
+
       lazy val log: Logger = streams.value.log
 
       (pushSiteWith.name, gitHosting.name) match {
@@ -508,11 +513,11 @@ trait MicrositeAutoImportSettings extends MicrositeKeys {
                  | * repo: $githubOwner/$githubRepo
                  | * commitMessage: $commitMessage""".stripMargin)
 
-            val ghOps: GitHubOps = new GitHubOps[IO](githubOwner, githubRepo, githubToken)
+            val ghOps: GitHubOps[IO] = new GitHubOps[IO](githubOwner, githubRepo, githubToken)
 
-//            if (noJekyll) FIO.touch(siteDir / ".nojekyll")
+            if (noJekyll) FIO.touch(siteDir / ".nojekyll")
 
-            ghOps.commitDir(branch, commitMessage, siteDir) match {
+            ghOps.commitDir(branch, commitMessage, siteDir).value.unsafeRunSync() match {
               case Right(_) => log.info("Success committing files")
               case Left(e) =>
                 log.error(s"Error committing files")


### PR DESCRIPTION
* Adds `cats-effect` as a dependency.
* Updates `sbt-org-policies` to `0.13.2` properly.
* Uses IO data type when committing a directory.