### PR TITLE
Fix distorted 2x jumbotron pattern

### DIFF
--- a/src/main/resources/_sass/_bootstrap_override.scss
+++ b/src/main/resources/_sass/_bootstrap_override.scss
@@ -37,7 +37,7 @@ body {
 	margin-bottom: 0;
 	background-attachment: fixed;
 	background: url('../img/jumbotron_pattern.png') fixed;
-	@include image-2x('../img/jumbotron_pattern2x.png', 56px,31px);
+	@include image-2x('../img/jumbotron_pattern2x.png', auto, auto);
 	h1 {
 		margin-bottom: ($line-height-computed * 1.8);
 	}


### PR DESCRIPTION
Despite the documentation saying that there isn't a size requirement for jumbotron patterns, it gets squished down to a fixed size on high density displays. This seems unintentional.

Fix it by changing the fixed size values to `auto`, which just uses the image size.

Bug in action on https://typelevel.org/cats:

![image](https://user-images.githubusercontent.com/4206232/81457397-be07a180-914a-11ea-9980-6821a3a8192d.png)

Fixed:

![image](https://user-images.githubusercontent.com/4206232/81457404-c7910980-914a-11ea-8283-e51f96625f9d.png)
