### PR TITLE
Fix windows path replacement

### DIFF
--- a/src/main/scala/microsites/ioops/ioops.scala
+++ b/src/main/scala/microsites/ioops/ioops.scala
@@ -53,7 +53,7 @@ package object ioops {
 
       def toFile: File = new File(filename.fixPath)
 
-      def fixPath: String = filename.replaceAll("/", File.separator)
+      def fixPath: String = filename.replaceAllLiterally("/", File.separator)
 
       def ensureFinalSlash: String =
         filename +


### PR DESCRIPTION
This is a partial fix for #488 

It bubbles up another error:

```
WARNING: All illegal access operations will be denied in a future release
[error] java.lang.IllegalArgumentException: requirement failed
[error]         at scala.Predef$.require(Predef.scala:268)
[error]         at com.sksamuel.scrimage.Image$.fromStream(Image.scala:856)
[error]         at com.sksamuel.scrimage.Image$.$anonfun$fromPath$1(Image.scala:878)
[error]         at com.sksamuel.scrimage.Using.using(Using.scala:7)
[error]         at com.sksamuel.scrimage.Using.using$(Using.scala:5)
[error]         at com.sksamuel.scrimage.Image$.using(Image.scala:807)
[error]         at com.sksamuel.scrimage.Image$.fromPath(Image.scala:878)
[error]         at com.sksamuel.scrimage.Image$.fromFile(Image.scala:875)
[error]         at microsites.util.MicrositeHelper.$anonfun$createFavicons$2(MicrositeHelper.scala:232)
[error]         at scala.collection.immutable.List.map(List.scala:286)
[error]         at microsites.util.MicrositeHelper.createFavicons(MicrositeHelper.scala:230)
[error]         at microsites.util.MicrositeHelper.createResources(MicrositeHelper.scala:112)
[error]         at microsites.MicrositeAutoImportSettings.$anonfun$micrositeTasksSettings$1(MicrositeKeys.scala:402)
[error]         at scala.Function1.$anonfun$compose$1(Function1.scala:49)
[error]         at sbt.internal.util.$tilde$greater.$anonfun$$u2219$1(TypeFunctions.scala:62)
[error]         at sbt.std.Transform$$anon$4.work(Transform.scala:67)
[error]         at sbt.Execute.$anonfun$submit$2(Execute.scala:281)
[error]         at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:19)
[error]         at sbt.Execute.work(Execute.scala:290)
[error]         at sbt.Execute.$anonfun$submit$1(Execute.scala:281)
[error]         at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:178)
[error]         at sbt.CompletionService$$anon$2.call(CompletionService.scala:37)
[error]         at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[error]         at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
[error]         at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[error]         at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
[error]         at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
[error]         at java.base/java.lang.Thread.run(Thread.java:834)
[error] (site / microsite) java.lang.IllegalArgumentException: requirement failed
```
