### PR TITLE
Update scrimage to 4.x from 2.x & fix copying resources

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ lazy val pluginSettings: Seq[Def.Setting[_]] = Seq(
     "com.47deg"             %% "github4s"        % "0.24.0",
     "net.jcazevedo"         %% "moultingyaml"    % "0.4.2",
     "com.lihaoyi"           %% "scalatags"       % "0.9.2",
-    "com.sksamuel.scrimage" %% "scrimage-core"   % "2.1.8",
+    "com.sksamuel.scrimage" %% "scrimage-scala"  % "4.0.12",
     "org.scalatestplus"     %% "scalacheck-1-14" % "3.1.4.0" % Test
   ),
   scriptedLaunchOpts ++= Seq(

--- a/project/dependencies.sbt
+++ b/project/dependencies.sbt
@@ -5,8 +5,8 @@ unmanagedResourceDirectories in Compile +=
   baseDirectory.in(ThisBuild).value.getParentFile / "src" / "main" / "resources"
 
 libraryDependencies ++= Seq(
-  "com.47deg"             %% "github4s"      % "0.24.0",
-  "net.jcazevedo"         %% "moultingyaml"  % "0.4.2",
-  "com.lihaoyi"           %% "scalatags"     % "0.9.2",
-  "com.sksamuel.scrimage" %% "scrimage-core" % "2.1.8"
+  "com.47deg"             %% "github4s"       % "0.24.0",
+  "net.jcazevedo"         %% "moultingyaml"   % "0.4.2",
+  "com.lihaoyi"           %% "scalatags"      % "0.9.2",
+  "com.sksamuel.scrimage" %% "scrimage-scala" % "4.0.12"
 )

--- a/src/main/scala/microsites/ioops/FileWriter.scala
+++ b/src/main/scala/microsites/ioops/FileWriter.scala
@@ -83,12 +83,9 @@ class FileWriter {
     def copyMultipleFiles(files: List[File]): IOResult[List[Path]] =
       files.traverse(copySingleFile)
 
-    println(sourcePath)
     for {
       files <- FileReader.fetchFilesRecursivelyFromPath(sourcePath)
-      _ = println(s"files: $files")
       paths <- copyMultipleFiles(files)
-      _ = println(s"paths: $paths")
     } yield paths
   }
 

--- a/src/main/scala/microsites/util/MicrositeHelper.scala
+++ b/src/main/scala/microsites/util/MicrositeHelper.scala
@@ -61,8 +61,9 @@ class MicrositeHelper(config: MicrositeSettings) {
       output: String,
       filter: String = ""
   ): Either[Exceptions.IOException, Any] =
-    copyJARResourcesTo(jarUrl, output, filter)
-      .orElse(copyFilesRecursively(jarUrl.getFile + filter, output + filter))
+    copyResourcesTo(jarUrl, output, filter).orElse(
+      copyFilesRecursively(jarUrl.getFile + filter, output + filter)
+    )
 
   def createResources(resourceManagedDir: File): List[File] = {
 

--- a/src/main/scala/microsites/util/MicrositeHelper.scala
+++ b/src/main/scala/microsites/util/MicrositeHelper.scala
@@ -20,7 +20,8 @@ import java.io.File
 import java.net.URL
 
 import cats.syntax.either._
-import com.sksamuel.scrimage._
+import com.sksamuel.scrimage.ImmutableImage
+import com.sksamuel.scrimage.implicits._
 import microsites.util.YamlFormats._
 import microsites._
 import microsites.layouts._
@@ -234,7 +235,7 @@ class MicrositeHelper(config: MicrositeSettings) {
         (new File(s"$targetDir$jekyllDir/img/$name"), size)
       }
       .map { case (file, (width, height)) =>
-        Image.fromFile(sourceFile.toFile).scaleTo(width, height).output(file)
+        ImmutableImage.loader.fromFile(sourceFile.toFile).scaleTo(width, height).output(file)
       }
   }
 


### PR DESCRIPTION
Scrimage, a dependency of sbt-microsites, has actually been significantly out of date for some time, probably due to a dependency name change from `scrimage-core` to `scrimage-scala` for the Scala-specific dependencies. This updates the library, and replaces the one usage of it using the latest syntax.

EDIT: The scope of this has expanded slightly to also fixing the build, by rewriting the `copyJARResourcesTo` function (now `copyResourcesFromFileSystem`) to work with arbitrary filesystems. While I'm not entirely sure what the cause of the build issues was, this issue might have had something to do with the specific JDK I am using (adoptopenjdk 8) as the issue was nonexistent before, and only popped up recently in the build.