### PR TITLE
Fix Gitter links in README and microsite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-[![Maven Central](https://img.shields.io/badge/maven%20central-1.2.1-green.svg)](https://repo1.maven.org/maven2/com/47deg/sbt-microsites_2.12_1.0) [![License](https://img.shields.io/badge/license-Apache%202-blue.svg)](https://raw.githubusercontent.com/47degrees/sbt-microsites/master/LICENSE) [![Join the chat at https://gitter.im/47degrees/sbt-microsites](https://badges.gitter.im/47degrees/sbt-microsites.svg)](https://gitter.im/47degrees/sbt-microsites?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![GitHub Issues](https://img.shields.io/github/issues/47degrees/sbt-microsites.svg)](https://github.com/47degrees/sbt-microsites/issues)
+[![Maven Central](https://img.shields.io/badge/maven%20central-1.2.1-green.svg)](https://repo1.maven.org/maven2/com/47deg/sbt-microsites_2.12_1.0) [![License](https://img.shields.io/badge/license-Apache%202-blue.svg)](https://raw.githubusercontent.com/47degrees/sbt-microsites/master/LICENSE) [![Join the chat at https://gitter.im/47deg/sbt-microsites](https://badges.gitter.im/47deg/sbt-microsites.svg)](https://gitter.im/47deg/sbt-microsites?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![GitHub Issues](https://img.shields.io/github/issues/47degrees/sbt-microsites.svg)](https://github.com/47degrees/sbt-microsites/issues)
 
 # sbt-microsites
 

--- a/build.sbt
+++ b/build.sbt
@@ -62,5 +62,6 @@ lazy val micrositeSettings: Seq[Def.Setting[_]] = Seq(
   micrositeDocumentationUrl := "docs",
   micrositeGithubToken := sys.env.get("GITHUB_TOKEN"),
   micrositePushSiteWith := GitHub4s,
+  micrositeGitterChannelUrl := "47deg/sbt-microsites",
   includeFilter in makeSite := "*.html" | "*.css" | "*.png" | "*.jpg" | "*.gif" | "*.js" | "*.swf" | "*.md" | "*.svg"
 )


### PR DESCRIPTION
The gitter link on the microsite and README is broken. This sets both to the proper values. There must have been some org change where this broke and it went unnoticed for a little while.