### PR TITLE
Update ScalaCheck to 1.15, scalatestplus scalacheck to 3.2.3.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -46,7 +46,6 @@ lazy val pluginSettings: Seq[Def.Setting[_]] = Seq(
     "com.sksamuel.scrimage" %% "scrimage-scala"  % "4.0.15",
     "org.scalatest"         %% "scalatest"       % "3.2.3"   % Test,
     "org.scalatestplus"     %% "scalacheck-1-15" % "3.2.3.0" % Test
-    "org.scalatestplus"     %% "scalacheck-1-14" % "3.1.4.0" % Test
   ),
   scriptedLaunchOpts ++= Seq(
     "-Xmx2048M",

--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,7 @@ lazy val pluginSettings: Seq[Def.Setting[_]] = Seq(
     "net.jcazevedo"         %% "moultingyaml"    % "0.4.2",
     "com.lihaoyi"           %% "scalatags"       % "0.9.3",
     "com.sksamuel.scrimage" %% "scrimage-scala"  % "4.0.12",
-    "org.scalatestplus"     %% "scalacheck-1-14" % "3.1.4.0" % Test
+    "org.scalatestplus"     %% "scalacheck-1-15" % "3.2.3.0" % Test
   ),
   scriptedLaunchOpts ++= Seq(
     "-Xmx2048M",

--- a/build.sbt
+++ b/build.sbt
@@ -44,6 +44,7 @@ lazy val pluginSettings: Seq[Def.Setting[_]] = Seq(
     "net.jcazevedo"         %% "moultingyaml"    % "0.4.2",
     "com.lihaoyi"           %% "scalatags"       % "0.9.3",
     "com.sksamuel.scrimage" %% "scrimage-scala"  % "4.0.12",
+    "org.scalatest"         %% "scalatest"       % "3.2.3"   % Test,
     "org.scalatestplus"     %% "scalacheck-1-15" % "3.2.3.0" % Test
   ),
   scriptedLaunchOpts ++= Seq(


### PR DESCRIPTION
Supersedes #499.

ScalaCheck updated to 1.15 a while back, and this transitively brings that in along with the latest scalatest version so we're not stuck on an old version of both.