### PR TITLE
Allow config to specify if home-page button goes to repo or docs

### DIFF
--- a/microsite/docs/docs/settings.md
+++ b/microsite/docs/docs/settings.md
@@ -290,6 +290,8 @@ Each file (the map key) can be related to a specific configuration through the `
 micrositePluginsDirectory := (resourceDirectory in Compile).value / "site" / "plugins"
 ```
 
+- `micrositeHomeButtonTarget`: Where the large "call-to-action button" on your home page should take users. By default is set to `repo` for your project repository. Can be set to `docs` to take users to the project documentation page, if configured.
+
 - `micrositeSearchEnabled`: Whether or not the search bar functionality is enabled for your microsite. Enabled by default. To disable, set to `false`.
 
 - `micrositeTheme`: You can choose two different themes to generate your microsite. By default it will display the `light` theme but you have the option of choosing the classic `pattern` theme.

--- a/src/main/resources/_sass/light-style/_features.scss
+++ b/src/main/resources/_sass/light-style/_features.scss
@@ -37,6 +37,7 @@
       margin: 0 0 10px 0;
     }
     .masthead-button {
+      text-align: center;
       width: 106px;
       margin-top: $base-point-grid * 2;
     }

--- a/src/main/resources/_sass/light-style/_masthead.scss
+++ b/src/main/resources/_sass/light-style/_masthead.scss
@@ -28,6 +28,7 @@
   }
 
   .masthead-button {
+    text-align: center;
     color: $white-color;
     padding: 11px ($base-point-grid * 5);
     border: 2px solid $white-color;

--- a/src/main/scala/microsites/MicrositeKeys.scala
+++ b/src/main/scala/microsites/MicrositeKeys.scala
@@ -367,7 +367,7 @@ trait MicrositeAutoImportSettings extends MicrositeKeys {
           micrositeBaseUrl = micrositeBaseUrl.value,
           micrositeDocumentationUrl = micrositeDocumentationUrl.value,
           micrositeDocumentationLabelDescription = micrositeDocumentationLabelDescription.value,
-          micrositeHomeButtonTarget = "repo"
+          micrositeHomeButtonTarget = micrositeHomeButtonTarget.value
         ),
         gitSettings = MicrositeGitSettings(
           githubOwner = micrositeGitHostingService.value match {

--- a/src/main/scala/microsites/MicrositeKeys.scala
+++ b/src/main/scala/microsites/MicrositeKeys.scala
@@ -214,6 +214,10 @@ trait MicrositeKeys {
   val micrositeSearchEnabled: SettingKey[Boolean] = settingKey[Boolean](
     "Adds a search bar and search features to your website using Lunr.js. Default is 'true'"
   )
+
+  val micrositeHomeButtonTarget: SettingKey[String] = settingKey[String](
+    "Determines where the large, home-page call-to-action button links to. Default is 'repo' which links to the project open source repository. Can also be set to `docs` to link to your main documentation page."
+  )
 }
 
 object MicrositeKeys extends MicrositeKeys
@@ -362,7 +366,8 @@ trait MicrositeAutoImportSettings extends MicrositeKeys {
           micrositeUrl = micrositeUrl.value,
           micrositeBaseUrl = micrositeBaseUrl.value,
           micrositeDocumentationUrl = micrositeDocumentationUrl.value,
-          micrositeDocumentationLabelDescription = micrositeDocumentationLabelDescription.value
+          micrositeDocumentationLabelDescription = micrositeDocumentationLabelDescription.value,
+          micrositeHomeButtonTarget = "repo"
         ),
         gitSettings = MicrositeGitSettings(
           githubOwner = micrositeGitHostingService.value match {

--- a/src/main/scala/microsites/MicrositesPlugin.scala
+++ b/src/main/scala/microsites/MicrositesPlugin.scala
@@ -123,6 +123,7 @@ object MicrositesPlugin extends AutoPlugin {
     micrositeEditButton := None,
     micrositeGithubLinks := true,
     micrositeSearchEnabled := true,
+    micrositeHomeButtonTarget := "repo",
     includeFilter in makeSite := "*.html" | "*.css" | "*.png" | "*.jpg" | "*.jpeg" | "*.gif" | "*.js" | "*.swf" | "*.md" | "*.webm" | "*.ico" | "CNAME" | "*.yml" | "*.svg" | "*.json",
     includeFilter in Jekyll := (includeFilter in makeSite).value || "LICENSE",
     commands ++= Seq(publishMicrositeCommand),

--- a/src/main/scala/microsites/layouts/FeaturesLayout.scala
+++ b/src/main/scala/microsites/layouts/FeaturesLayout.scala
@@ -50,13 +50,7 @@ class FeaturesLayout(config: MicrositeSettings) extends Layout(config) {
             cls := "features-header-description",
             h1(cls := "masthead-title", config.identity.name),
             p(cls := "masthead-description", config.identity.description),
-            a(
-              href := config.gitSiteUrl,
-              target := "_blank",
-              rel := "noopener noreferrer",
-              cls := "masthead-button",
-              s"View on ${config.gitSettings.gitHostingService.name}"
-            )
+            ctaButton("masthead-button")
           ),
           div(cls := "features-image")
         )

--- a/src/main/scala/microsites/layouts/HomeLayout.scala
+++ b/src/main/scala/microsites/layouts/HomeLayout.scala
@@ -71,13 +71,7 @@ class HomeLayout(config: MicrositeSettings) extends Layout(config) {
           h2(),
           p(
             cls := "text-center",
-            a(
-              href := config.gitSiteUrl,
-              target := "_blank",
-              rel := "noopener noreferrer",
-              cls := "btn btn-outline-inverse",
-              s"View on ${config.gitSettings.gitHostingService.name}"
-            )
+            ctaButton("btn btn-outline-inverse")
           )
         )
       ),
@@ -91,13 +85,7 @@ class HomeLayout(config: MicrositeSettings) extends Layout(config) {
         div(
           cls := "container text-center",
           h1(cls := "masthead-description", config.identity.description),
-          a(
-            href := config.gitSiteUrl,
-            target := "_blank",
-            rel := "noopener noreferrer",
-            cls := "masthead-button",
-            s"View on ${config.gitSettings.gitHostingService.name}"
-          )
+          ctaButton("masthead-button")
         )
       ),
       "{% if page.position != null %}",

--- a/src/main/scala/microsites/layouts/Layout.scala
+++ b/src/main/scala/microsites/layouts/Layout.scala
@@ -557,4 +557,24 @@ abstract class Layout(config: MicrositeSettings) {
 
   private[this] def validFile(extension: String)(file: File): Boolean =
     file.getName.endsWith(s".$extension")
+
+  def ctaButton(linkClass: String): TypedTag[String] = {
+    if (config.urlSettings.micrositeHomeButtonTarget == "repo") {
+      a(
+        href := config.gitSiteUrl,
+        target := "_blank",
+        rel := "noopener noreferrer",
+        cls := linkClass,
+        s"View on ${config.gitSettings.gitHostingService.name}"
+      )
+    } else {
+      a(
+        href := s"/${config.urlSettings.micrositeBaseUrl}${config.urlSettings.micrositeDocumentationUrl}",
+        target := "_blank",
+        rel := "noopener noreferrer",
+        cls := linkClass,
+        s"View Docs"
+      )
+    }
+  }
 }

--- a/src/main/scala/microsites/layouts/Layout.scala
+++ b/src/main/scala/microsites/layouts/Layout.scala
@@ -569,7 +569,7 @@ abstract class Layout(config: MicrositeSettings) {
       )
     } else {
       a(
-        href := s"/${config.urlSettings.micrositeBaseUrl}${config.urlSettings.micrositeDocumentationUrl}",
+        href := s"/${config.urlSettings.micrositeBaseUrl}/${config.urlSettings.micrositeDocumentationUrl}",
         target := "_blank",
         rel := "noopener noreferrer",
         cls := linkClass,

--- a/src/main/scala/microsites/microsites.scala
+++ b/src/main/scala/microsites/microsites.scala
@@ -58,7 +58,8 @@ case class MicrositeUrlSettings(
     micrositeUrl: String,
     micrositeBaseUrl: String,
     micrositeDocumentationUrl: String,
-    micrositeDocumentationLabelDescription: String
+    micrositeDocumentationLabelDescription: String,
+    micrositeHomeButtonTarget: String
 )
 
 case class MicrositeFavicon(filename: String, sizeDescription: String)

--- a/src/test/scala/microsites/util/Arbitraries.scala
+++ b/src/test/scala/microsites/util/Arbitraries.scala
@@ -22,6 +22,7 @@ import microsites.MicrositeKeys._
 import microsites._
 import org.scalacheck.Arbitrary
 import org.scalacheck.Gen._
+import org.scalacheck.Gen
 
 trait Arbitraries {
 
@@ -143,6 +144,7 @@ trait Arbitraries {
         micrositeEditButton                    ← micrositeEditButtonArbitrary.arbitrary
         micrositeVersionList                   ← Arbitrary.arbitrary[Seq[String]]
         micrositeSearchBar                    <- Arbitrary.arbitrary[Boolean]
+        micrositeHomeButtonTarget             <- Gen.oneOf("docs", "repo")
       } yield MicrositeSettings(
         MicrositeIdentitySettings(
           name,
@@ -184,7 +186,8 @@ trait Arbitraries {
           micrositeUrl,
           micrositeBaseUrl,
           micrositeDocumentationUrl,
-          micrositeDocumentationLabelDescription
+          micrositeDocumentationLabelDescription,
+          micrositeHomeButtonTarget
         ),
         MicrositeGitSettings(
           githubOwner,


### PR DESCRIPTION
Resolves #508

Adds a config option for specifying where you would like the big call-to-action button on the front page to link to, between your `repo` or your `docs` page.
Simply set `micrositeHomeButtonTarget := "docs"` and you will get a button that looks like this:

<img width="396" alt="Screen Shot 2021-01-27 at 3 22 53 PM" src="https://user-images.githubusercontent.com/427237/106055833-8adbb880-60b3-11eb-87dc-4d2bbb08da98.png">

and redirects to your documents URL, assuming it is defined.
