### PR TITLE
Enable Search for Pattern Theme

### DIFF
--- a/src/main/resources/_sass/_doc-search.scss
+++ b/src/main/resources/_sass/_doc-search.scss
@@ -9,6 +9,7 @@
 
   label {
     padding-right: 0.3em;
+    font-weight: normal;
 
     i {
       padding-right: 0.2em;

--- a/src/main/resources/_sass/_doc-search.scss
+++ b/src/main/resources/_sass/_doc-search.scss
@@ -1,4 +1,4 @@
-div[id$='search-dropdown'] {
+#search-dropdown {
   position: relative;
 
   .dropdown {
@@ -32,6 +32,7 @@ div[id$='search-dropdown'] {
 
     .dropdown-item {
       width: 100%;
+      text-align: left;
 
       .dropdown-item-link {
         padding: 12px 9px;

--- a/src/main/resources/_sass/_docs.scss
+++ b/src/main/resources/_sass/_docs.scss
@@ -49,7 +49,6 @@
                 span {
                     margin-left: 10px;
                     font-size: 14px;
-                    text-transform: uppercase;
                 }
             }
         }
@@ -106,6 +105,10 @@
         .header-link {
             opacity: 1;
         }
+    }
+
+    .to-uppercase {
+        text-transform: uppercase;
     }
 }
 

--- a/src/main/resources/_sass/_home.scss
+++ b/src/main/resources/_sass/_home.scss
@@ -52,12 +52,6 @@
                         .fa-file-text {
                             font-size: 17px;
                         }
-                        &:hover,
-                        &:focus,
-                        &.focus {
-                            opacity: 0.5;
-                            text-decoration: none;
-                        }
                     }
 
                     label {
@@ -81,6 +75,15 @@
                 }
             }
         }
+    }
+}
+
+a.transparent-on-hover {
+    &:hover,
+    &:focus,
+    &.focus {
+        opacity: 0.5;
+        text-decoration: none;
     }
 }
 

--- a/src/main/resources/_sass/_home.scss
+++ b/src/main/resources/_sass/_home.scss
@@ -60,7 +60,18 @@
                         }
                     }
 
-                    &:first-child {
+                    label {
+                        color: #fff;
+                        font-size: 15px;
+                        font-weight: 400;
+                        margin-right: 6px;
+
+                        i {
+                            margin-right: 6px;
+                        }
+                    }
+
+                    &:not(:last-child) {
                         margin-right: 50px;
 
                         @media screen and (max-width: $screen-xs-max) {

--- a/src/main/resources/css/light-style.scss
+++ b/src/main/resources/css/light-style.scss
@@ -12,7 +12,7 @@
 @import "light-style/button";
 @import "light-style/masthead";
 @import "light-style/main";
-@import "light-style/doc-search";
+@import "doc-search";
 @import "light-style/doc-versions";
 @import "light-style/footer";
 @import "light-style/light-docs";

--- a/src/main/resources/css/pattern-style.scss
+++ b/src/main/resources/css/pattern-style.scss
@@ -8,5 +8,6 @@
 @import "bootstrap";
 @import "bootstrap_override";
 @import "docs";
+@import "doc-search";
 @import "home";
 @import "colors";

--- a/src/main/resources/js/main.js
+++ b/src/main/resources/js/main.js
@@ -53,11 +53,6 @@ function shareSiteTwitter(text) {
   return false;
 }
 
-function shareSiteGoogle() {
-  launchPopup('https://plus.google.com/share?url='+baseURL);
-  return false;
-}
-
 function launchPopup(url) {
   window.open(url, 'Social Share', 'height=320, width=640, toolbar=no, menubar=no, scrollbars=no, resizable=no, location=no, directories=no, status=no');
 }

--- a/src/main/scala/microsites/layouts/DocsLayout.scala
+++ b/src/main/scala/microsites/layouts/DocsLayout.scala
@@ -100,8 +100,7 @@ class DocsLayout(config: MicrositeSettings) extends Layout(config) {
             li(a(href := "#", onclick := s"shareSiteTwitter('$text');", i(cls := "fa fa-twitter"))),
             li(
               a(href := "#", onclick := s"shareSiteFacebook('$text');", i(cls := "fa fa-facebook"))
-            ),
-            li(a(href := "#", onclick := "shareSiteGoogle();", i(cls := "fa fa-google-plus")))
+            )
           )
         } else Seq.empty
       } else Seq.empty

--- a/src/main/scala/microsites/layouts/DocsLayout.scala
+++ b/src/main/scala/microsites/layouts/DocsLayout.scala
@@ -36,10 +36,14 @@ class DocsLayout(config: MicrositeSettings) extends Layout(config) {
     val text = s"${config.identity.name} ${config.identity.description}"
 
     def siteSearch: Seq[TypedTag[String]] = {
+      val classes =
+        if (config.visualSettings.theme == "pattern") "search-nav hidden-xs hidden-sm"
+        else "search-nav"
+
       if (config.searchSettings.searchEnabled) {
         Seq(
           li(
-            cls := "search-nav",
+            cls := classes,
             div(
               id := "search-dropdown",
               label(
@@ -69,7 +73,7 @@ class DocsLayout(config: MicrositeSettings) extends Layout(config) {
         Seq(
           li(
             id := "gh-eyes-item",
-            cls := "hidden-xs",
+            cls := "hidden-xs to-uppercase",
             a(
               href := config.gitSiteUrl,
               target := "_blank",
@@ -80,7 +84,7 @@ class DocsLayout(config: MicrositeSettings) extends Layout(config) {
           ),
           li(
             id := "gh-stars-item",
-            cls := "hidden-xs",
+            cls := "hidden-xs to-uppercase",
             a(
               href := config.gitSiteUrl,
               target := "_blank",
@@ -107,7 +111,7 @@ class DocsLayout(config: MicrositeSettings) extends Layout(config) {
     }
 
     val maybeSearch =
-      if (config.visualSettings.theme != "pattern" && config.searchSettings.searchEnabled) {
+      if (config.searchSettings.searchEnabled) {
         Seq(siteSearch)
       } else Seq.empty
 
@@ -306,7 +310,10 @@ class DocsLayout(config: MicrositeSettings) extends Layout(config) {
     if (config.visualSettings.theme == "pattern") scriptsDocsPattern else scriptsDocsLight
 
   def scriptsDocsPattern: List[TypedTag[String]] =
-    scripts ++ List(script(src := "{{ site.baseurl }}/js/main.js"))
+    scripts ++ List(
+      searchScript,
+      script(src := "{{ site.baseurl }}/js/main.js")
+    )
 
   def scriptsDocsLight: List[TypedTag[String]] =
     scripts ++ List(

--- a/src/main/scala/microsites/layouts/HomeLayout.scala
+++ b/src/main/scala/microsites/layouts/HomeLayout.scala
@@ -52,14 +52,14 @@ class HomeLayout(config: MicrositeSettings) extends Layout(config) {
           div(
             cls := "row",
             div(
-              cls := "col-xs-6",
+              cls := "col-xs-3",
               a(
                 href := "{{ site.baseurl }}/",
                 cls := "brand",
                 div(cls := "icon-wrapper", span(config.identity.name))
               )
             ),
-            div(cls := "col-xs-6", buildCollapseMenu)
+            div(cls := "col-xs-9", buildCollapseMenu)
           )
         )
       ),

--- a/src/main/scala/microsites/layouts/Layout.scala
+++ b/src/main/scala/microsites/layouts/Layout.scala
@@ -450,6 +450,7 @@ abstract class Layout(config: MicrositeSettings) {
         searchBar,
         li(
           a(
+            cls := "transparent-on-hover",
             href := config.gitSiteUrl,
             i(cls := s"fa ${config.gitHostingIconClass}"),
             target := "_blank",
@@ -460,6 +461,7 @@ abstract class Layout(config: MicrositeSettings) {
         if (!config.urlSettings.micrositeDocumentationUrl.isEmpty)
           li(
             a(
+              cls := "transparent-on-hover",
               href := s"${config.urlSettings.micrositeDocumentationUrl}",
               i(cls := "fa fa-file-text"),
               span(

--- a/src/main/scala/microsites/layouts/Layout.scala
+++ b/src/main/scala/microsites/layouts/Layout.scala
@@ -411,18 +411,50 @@ abstract class Layout(config: MicrositeSettings) {
     )
   }
 
+  def searchBar: Option[TypedTag[String]] = {
+    val classes =
+      if (config.visualSettings.theme == "pattern") "search-nav hidden-xs"
+      else "search-nav"
+
+    if (config.searchSettings.searchEnabled) {
+      Some(
+        li(
+          cls := classes,
+          div(
+            id := "search-dropdown",
+            label(
+              i(cls := "fa fa-search"),
+              "Search"
+            ),
+            input(
+              id := "search-bar",
+              `type` := "text",
+              placeholder := "Enter keywords here...",
+              onclick := "displayToggleSearch(event)"
+            ),
+            ul(
+              id := "search-dropdown-content",
+              cls := "dropdown dropdown-content"
+            )
+          )
+        )
+      )
+    } else Option.empty
+  }
+
   def buildCollapseMenu: TypedTag[String] =
     nav(
       cls := "text-right",
       ul(
         cls := "",
+        searchBar,
         li(
           a(
             href := config.gitSiteUrl,
             i(cls := s"fa ${config.gitHostingIconClass}"),
             target := "_blank",
             rel := "noopener noreferrer",
-            span(cls := "hidden-xs", config.gitSettings.gitHostingService.name)
+            span(cls := "hidden-sm hidden-xs", config.gitSettings.gitHostingService.name)
           )
         ),
         if (!config.urlSettings.micrositeDocumentationUrl.isEmpty)
@@ -430,7 +462,10 @@ abstract class Layout(config: MicrositeSettings) {
             a(
               href := s"${config.urlSettings.micrositeDocumentationUrl}",
               i(cls := "fa fa-file-text"),
-              span(cls := "hidden-xs", config.urlSettings.micrositeDocumentationLabelDescription)
+              span(
+                cls := "hidden-sm hidden-xs",
+                config.urlSettings.micrositeDocumentationLabelDescription
+              )
             )
           )
         else ()
@@ -439,28 +474,7 @@ abstract class Layout(config: MicrositeSettings) {
 
   def buildLightCollapseMenu: TypedTag[String] =
     ul(
-      "{% if site.search_enabled %}",
-      li(
-        cls := "search-nav",
-        div(
-          id := "search-dropdown",
-          label(
-            i(cls := "fa fa-search"),
-            "Search"
-          ),
-          input(
-            id := "search-bar",
-            `type` := "text",
-            placeholder := "Enter keywords here...",
-            onclick := "displayToggleSearch(event)"
-          ),
-          ul(
-            id := "search-dropdown-content",
-            cls := "dropdown dropdown-content"
-          )
-        )
-      ),
-      "{% endif %}",
+      searchBar,
       "{% if site.data.versions %}",
       raw("""{% assign own_version = site.data.versions | where: "own", true | first %}"""),
       li(


### PR DESCRIPTION
Resolves #542 

Enables search for the pattern theme! A lot of older microsites are still using this theme so it's good that search is available to it. I had some difficulty meshing the style of the light theme with the pattern theme, and it might look a bit visually inconsistent in some small areas, but I feel this is at least a good start.

Also removes the Google+ share-on-social link, as that service has been discontinued for some time. It also made it easier to adjust the CSS with it gone as there was more room to play with.

Pic examples of the search in pattern theme:
<img width="575" alt="Screen Shot 2021-02-01 at 5 17 50 PM" src="https://user-images.githubusercontent.com/427237/106530265-9cf19880-64b1-11eb-8167-376c272a9e60.png">
<img width="880" alt="Screen Shot 2021-02-01 at 5 18 58 PM" src="https://user-images.githubusercontent.com/427237/106530269-9ebb5c00-64b1-11eb-9363-0e583af9f70f.png">

I made sure that the CSS changes here didn't override any previous visual settings, so the rest of the navbar links still have transparency on hover, docs navbar entries are still uppercase without affecting search results, etc.
