### PR TITLE
Remove Scrimage classloader hack

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,7 @@ lazy val pluginSettings: Seq[Def.Setting[_]] = Seq(
     "org.http4s"            %% "http4s-blaze-client" % "0.21.18",
     "net.jcazevedo"         %% "moultingyaml"        % "0.4.2",
     "com.lihaoyi"           %% "scalatags"           % "0.9.3",
-    "com.sksamuel.scrimage" %% "scrimage-scala"      % "4.0.16",
+    "com.sksamuel.scrimage" %% "scrimage-scala"      % "4.0.17",
     "org.scalatest"         %% "scalatest"           % "3.2.3"   % Test,
     "org.scalatestplus"     %% "scalacheck-1-15"     % "3.2.3.0" % Test
   ),

--- a/project/dependencies.sbt
+++ b/project/dependencies.sbt
@@ -8,5 +8,5 @@ libraryDependencies ++= Seq(
   "com.47deg"             %% "github4s"       % "0.24.0",
   "net.jcazevedo"         %% "moultingyaml"   % "0.4.2",
   "com.lihaoyi"           %% "scalatags"      % "0.9.3",
-  "com.sksamuel.scrimage" %% "scrimage-scala" % "4.0.16"
+  "com.sksamuel.scrimage" %% "scrimage-scala" % "4.0.17"
 )


### PR DESCRIPTION
Resolves #535 

Scrimage now allows you to pass in a classloader, so we don't need to override the one the plugin uses by default.