### PR TITLE
Restores old encoding

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -44,6 +44,7 @@ lazy val pluginSettings: Seq[Def.Setting[_]] = Seq(
     "net.jcazevedo"         %% "moultingyaml"        % "0.4.2",
     "com.lihaoyi"           %% "scalatags"           % "0.12.0",
     "com.sksamuel.scrimage" %% "scrimage-scala"      % "4.0.32",
+    "com.github.marklister" %% "base64"              % "0.3.0",
     "org.scalatest"         %% "scalatest"           % "3.2.14"   % Test,
     "org.scalatestplus"     %% "scalacheck-1-15"     % "3.2.11.0" % Test
   ),

--- a/project/dependencies.sbt
+++ b/project/dependencies.sbt
@@ -9,5 +9,6 @@ libraryDependencies ++= Seq(
   "org.http4s"            %% "http4s-blaze-client" % "0.23.13",
   "net.jcazevedo"         %% "moultingyaml"        % "0.4.2",
   "com.lihaoyi"           %% "scalatags"           % "0.12.0",
-  "com.sksamuel.scrimage" %% "scrimage-scala"      % "4.0.32"
+  "com.sksamuel.scrimage" %% "scrimage-scala"      % "4.0.32",
+  "com.github.marklister" %% "base64"              % "0.3.0"
 )

--- a/src/main/scala/microsites/github/GitHubOps.scala
+++ b/src/main/scala/microsites/github/GitHubOps.scala
@@ -22,6 +22,7 @@ import cats.data.{NonEmptyList, OptionT}
 import cats.effect.{Ref => _, _}
 import cats.effect.kernel.Temporal
 import cats.implicits._
+import com.github.marklister.base64.Base64._
 import github4s._
 import github4s.domain._
 import microsites.Exceptions._
@@ -115,15 +116,7 @@ class GitHubOps[F[_]: Async: Temporal](
       ): F[TreeDataSha] =
         for {
           gh <- ghWithRateLimit
-          res <- run(
-            gh.gitData.createBlob(
-              owner,
-              repo,
-              Base64.getEncoder().encode(array).mkString(""),
-              Some("base64"),
-              headers
-            )
-          )
+          res <- run(gh.gitData.createBlob(owner, repo, array.toBase64, Some("base64"), headers))
             .map(refInfo => TreeDataSha(filePath, blobMode, blobType, refInfo.sha))
         } yield res
 


### PR DESCRIPTION
This restores the changes made in b9bbd817bef7790a3c00f74cbbf7822dd15fd6b0 regarding base64 encoding. Tested locally and it seems to work now (see https://github.com/47degrees/sbt-microsites/commit/d3c35c279115489c528c23f66d76a80c0f9cb332)

Related to #727