### PR TITLE
Fix UnauthorizedError on GitHub Enterprise publish

### DIFF
--- a/src/main/scala/microsites/MicrositeKeys.scala
+++ b/src/main/scala/microsites/MicrositeKeys.scala
@@ -563,7 +563,7 @@ trait MicrositeAutoImportSettings extends MicrositeKeys {
         val replaceHost: String => String = s => s.replace("github.com", url.getHost)
         GithubConfig.default
           .copy(
-            baseUrl = replaceHost(s"${GithubConfig.default.baseUrl}"),
+            baseUrl = s"${url.getProtocol}://${url.getHost}/api/v3/",
             authorizeUrl = replaceHost(s"${GithubConfig.default.authorizeUrl}"),
             accessTokenUrl = replaceHost(s"${GithubConfig.default.accessTokenUrl}")
           )

--- a/src/main/scala/microsites/MicrositeKeys.scala
+++ b/src/main/scala/microsites/MicrositeKeys.scala
@@ -497,7 +497,8 @@ trait MicrositeAutoImportSettings extends MicrositeKeys {
 
                 implicit val config: GithubConfig =
                   buildGithubConfig(micrositeGitHostingUrl.value)(log)
-                val ghOps = new GitHubOps[IO](client, githubOwner, githubRepo, githubToken)
+                val ghOps: GitHubOps[IO] =
+                  new GitHubOps[IO](client, githubOwner, githubRepo, githubToken)
 
                 if (noJekyll) FIO.touch(siteDir / ".nojekyll")
 
@@ -564,8 +565,8 @@ trait MicrositeAutoImportSettings extends MicrositeKeys {
         GithubConfig.default
           .copy(
             baseUrl = s"${url.getProtocol}://${url.getHost}/api/v3/",
-            authorizeUrl = replaceHost(s"${GithubConfig.default.authorizeUrl}"),
-            accessTokenUrl = replaceHost(s"${GithubConfig.default.accessTokenUrl}")
+            authorizeUrl = replaceHost(GithubConfig.default.authorizeUrl),
+            accessTokenUrl = replaceHost(GithubConfig.default.accessTokenUrl)
           )
       case Right(url) =>
         log.warn(s"Invalid protocol: ${url.getProtocol}")

--- a/src/main/scala/microsites/MicrositeKeys.scala
+++ b/src/main/scala/microsites/MicrositeKeys.scala
@@ -558,6 +558,7 @@ trait MicrositeAutoImportSettings extends MicrositeKeys {
 
   protected[this] def buildGithubConfig(hostingUrl: String)(implicit log: Logger): GithubConfig =
     Either.catchOnly[MalformedURLException](new URL(hostingUrl)) match {
+      case Right(url) if url.getHost == "github.com" => GithubConfig.default
       case Right(url) if url.getProtocol.startsWith("https") =>
         val replaceHost: String => String = s => s.replace("github.com", url.getHost)
         GithubConfig.default

--- a/src/main/scala/microsites/github/GitHubOps.scala
+++ b/src/main/scala/microsites/github/GitHubOps.scala
@@ -39,9 +39,9 @@ class GitHubOps[F[_]: Async: Temporal](
     repo: String,
     accessToken: Option[String],
     fileReader: FileReader = FileReader
-) {
+)(implicit val config: GithubConfig) {
 
-  private val gh: Github[F]                = Github[F](client, accessToken)
+  private val gh: Github[F]                = Github[F](client, accessToken)(implicitly, config)
   private val headers: Map[String, String] = Map("user-agent" -> "sbt-microsites")
 
   def commitDir(branch: String, message: String, dir: File): F[Ref] =

--- a/src/main/scala/microsites/github/GitHubOps.scala
+++ b/src/main/scala/microsites/github/GitHubOps.scala
@@ -41,7 +41,7 @@ class GitHubOps[F[_]: Async: Temporal](
     fileReader: FileReader = FileReader
 )(implicit val config: GithubConfig) {
 
-  private val gh: Github[F]                = Github[F](client, accessToken)(implicitly, config)
+  private val gh: Github[F]                = Github[F](client, accessToken)
   private val headers: Map[String, String] = Map("user-agent" -> "sbt-microsites")
 
   def commitDir(branch: String, message: String, dir: File): F[Ref] =

--- a/src/test/scala/microsites/MicrositeAutoImportSettingsTest.scala
+++ b/src/test/scala/microsites/MicrositeAutoImportSettingsTest.scala
@@ -60,7 +60,7 @@ class MicrositeAutoImportSettingsTest
         val actualGitBaseUrl = new URL(githubConfig.baseUrl)
         actualGitBaseUrl.getProtocol shouldBe "https"
         actualGitBaseUrl.getHost shouldBe gitSiteUrl.getHost
-        actualGitBaseUrl.getPath shouldBe "/api/v3"
+        actualGitBaseUrl.getPath shouldBe "/api/v3/"
 
         val actualGitAuthorizeUrl = new URL(githubConfig.authorizeUrl)
         actualGitAuthorizeUrl.getProtocol shouldBe "https"

--- a/src/test/scala/microsites/MicrositeAutoImportSettingsTest.scala
+++ b/src/test/scala/microsites/MicrositeAutoImportSettingsTest.scala
@@ -59,8 +59,8 @@ class MicrositeAutoImportSettingsTest
 
         val actualGitBaseUrl = new URL(githubConfig.baseUrl)
         actualGitBaseUrl.getProtocol shouldBe "https"
-        actualGitBaseUrl.getHost shouldBe s"api.${gitSiteUrl.getHost}"
-        actualGitBaseUrl.getPath shouldBe new URL(GithubConfig.default.baseUrl).getPath
+        actualGitBaseUrl.getHost shouldBe gitSiteUrl.getHost
+        actualGitBaseUrl.getPath shouldBe "/api/v3"
 
         val actualGitAuthorizeUrl = new URL(githubConfig.authorizeUrl)
         actualGitAuthorizeUrl.getProtocol shouldBe "https"

--- a/src/test/scala/microsites/MicrositeAutoImportSettingsTest.scala
+++ b/src/test/scala/microsites/MicrositeAutoImportSettingsTest.scala
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2016-2023 47 Degrees Open Source <https://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package microsites
+
+import github4s.GithubConfig
+import microsites.util.Arbitraries
+import org.scalacheck.Prop.*
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.Checkers
+import sbt.Logger
+
+import java.net.URL
+
+class MicrositeAutoImportSettingsTest
+    extends AnyFunSuite
+    with Checkers
+    with Matchers
+    with Arbitraries
+    with MicrositeAutoImportSettings {
+
+  test("buildGithubConfig should return default GitHub config when invalid Git hosting URL") {
+    val property = forAll(
+      settingsArbitrary.arbitrary suchThat (!_.gitSettings.gitHostingUrl.startsWith("https://"))
+    ) {
+      settings: MicrositeSettings ⇒
+        implicit val log: Logger = Logger.Null
+        val githubConfig         = buildGithubConfig(settings.gitSettings.gitHostingUrl)
+
+        githubConfig shouldBe GithubConfig.default
+        githubConfig.baseUrl.nonEmpty
+    }
+
+    check(property)
+  }
+
+  test("buildGithubConfig should override GitHub config when valid Git hosting URL") {
+    val property = forAll(
+      settingsArbitrary.arbitrary suchThat (_.gitSettings.gitHostingUrl.startsWith("https://"))
+    ) {
+      settings: MicrositeSettings ⇒
+        implicit val log: Logger = Logger.Null
+        val gitSiteUrl           = new URL(settings.gitSettings.gitHostingUrl)
+        val githubConfig         = buildGithubConfig(gitSiteUrl.toString)
+
+        val actualGitBaseUrl = new URL(githubConfig.baseUrl)
+        actualGitBaseUrl.getProtocol shouldBe "https"
+        actualGitBaseUrl.getHost shouldBe s"api.${gitSiteUrl.getHost}"
+        actualGitBaseUrl.getPath shouldBe new URL(GithubConfig.default.baseUrl).getPath
+
+        val actualGitAuthorizeUrl = new URL(githubConfig.authorizeUrl)
+        actualGitAuthorizeUrl.getProtocol shouldBe "https"
+        actualGitAuthorizeUrl.getHost shouldBe gitSiteUrl.getHost
+        actualGitAuthorizeUrl.getPath shouldBe new URL(GithubConfig.default.authorizeUrl).getPath
+        actualGitAuthorizeUrl.getQuery shouldBe new URL(GithubConfig.default.authorizeUrl).getQuery
+
+        val actualGitAccessTokenUrl = new URL(githubConfig.accessTokenUrl)
+        actualGitAccessTokenUrl.getProtocol shouldBe "https"
+        actualGitAccessTokenUrl.getHost shouldBe gitSiteUrl.getHost
+        actualGitAccessTokenUrl.getPath shouldBe new URL(
+          GithubConfig.default.accessTokenUrl
+        ).getPath
+        actualGitAccessTokenUrl.getQuery shouldBe new URL(
+          GithubConfig.default.accessTokenUrl
+        ).getQuery
+
+        githubConfig.baseUrl.nonEmpty
+    }
+
+    check(property)
+  }
+}

--- a/src/test/scala/microsites/util/Arbitraries.scala
+++ b/src/test/scala/microsites/util/Arbitraries.scala
@@ -24,6 +24,8 @@ import org.scalacheck.Arbitrary
 import org.scalacheck.Gen
 import org.scalacheck.Gen.*
 
+import java.net.URL
+
 trait Arbitraries {
 
   implicit def fileArbitrary: Arbitrary[File] =
@@ -99,6 +101,16 @@ trait Arbitraries {
       } yield Some(MicrositeEditButton(text, basePath))
     }
 
+  implicit val urlArbitrary: Arbitrary[URL] =
+    Arbitrary {
+      for {
+        protocol <- Gen.oneOf("http", "https", "ftp", "file")
+        domain   <- Gen.alphaNumStr
+        tld      <- Gen.oneOf("com", "io", "net")
+        path     <- Gen.alphaNumStr
+      } yield new URL(s"$protocol://$domain.$tld/$path")
+    }
+
   implicit def settingsArbitrary: Arbitrary[MicrositeSettings] =
     Arbitrary {
       for {
@@ -135,7 +147,7 @@ trait Arbitraries {
         githubOwner               <- Arbitrary.arbitrary[String]
         githubRepo                <- Arbitrary.arbitrary[String]
         gitHostingService         <- Arbitrary.arbitrary[GitHostingService]
-        gitHostingUrl             <- Arbitrary.arbitrary[String]
+        gitHostingUrl             <- Arbitrary.arbitrary[URL]
         githubLinks               <- Arbitrary.arbitrary[Boolean]
         gitSidecarChat            <- Arbitrary.arbitrary[Boolean]
         gitSidecarChatUrl         <- Arbitrary.arbitrary[String]
@@ -194,7 +206,7 @@ trait Arbitraries {
           githubRepo,
           githubLinks,
           gitHostingService,
-          gitHostingUrl,
+          gitHostingUrl.toString, // ToDo: Change to URL type on codebase
           gitSidecarChat,
           gitSidecarChatUrl
         ),


### PR DESCRIPTION
When `gitHostingURL` is set, we see the following error:

```
Error making request to GitHub
 | => bat microsites.github.GitHubOps.$anonfun$run$1(GitHubOps.scala:208)
	at uncancelable @ org.http4s.client.ConnectionManager$.pool(ConnectionManager.scala:83)
	at uncancelable @ org.http4s.client.ConnectionManager$.pool(ConnectionManager.scala:83)
	at flatMap @ org.http4s.client.PoolManager.releaseRecyclable(PoolManager.scala:225)
	at uncancelable @ org.http4s.client.ConnectionManager$.pool(ConnectionManager.scala:83)
	at unsafeRunSync @ microsites.MicrositeAutoImportSettings.$anonfun$micrositeTasksSettings$14(MicrositeKeys.scala:496)
	at withPermit @ org.http4s.client.PoolManager.shutdown(PoolManager.scala:370)
	at uncancelable @ org.http4s.client.ConnectionManager$.pool(ConnectionManager.scala:83)
	at withPermit @ org.http4s.client.PoolManager.shutdown(PoolManager.scala:370)
	at guarantee$extension @ org.http4s.client.blaze.Http1Connection.$anonfun$executeRequest$2(Http1Connection.scala:193)
	at map @ fs2.internal.CompileScope.$anonfun$close$9(CompileScope.scala:246)
Caused by: UnauthorizedError(Bad credentials, https://docs.github.com/rest)

```

We need to adjust GithubConfig base/authorize/accessToken URLs to contain the `gitHostingURL` host.

---

@TomyMeren , can you:
1. Clone my repo (branch fix/github_enterprise)
2. Run publishLocal (haven't checked but should be configured)
3. On your repo, change resolver to include resolvers += Resolver.mavenLocal, adjust github4s version to this published version
4. Compile, run and inform if it's now working

---
